### PR TITLE
Fix error image mimetype

### DIFF
--- a/src/Services/FileService.php
+++ b/src/Services/FileService.php
@@ -142,14 +142,15 @@ class FileService extends BaseService
         if ($fileData != null && file_exists($path . $fileData->path . '/' . $fileData->name)) {
             $imageName = $fileData->name;
             $path .= $fileData->path;
-            $mimeType = $fileData->mime;
+            $mimeType = $fileData->mime->name;
         } else {
             $imageName = 'default.jpg';
             $mimeType = 'image/png';
             $path .= 'default';
         }
     
-        $isImage = strpos($mimeType, 'image');
+        $isImage = strpos($mimeType, 'image') !== false;
+        
         if ($isImage && !$download) {
             $image = new ImageResize($path . '/' . $imageName);
     


### PR DESCRIPTION
### Problems
Currently it returns wrong mimetype for image file causing error on browser when tried to render the image.

1. Error in devtools console telling the images were 404 not found, although they were displayed on screen.
![Screen Shot 2019-08-06 at 01 21 59](https://user-images.githubusercontent.com/914534/62486373-4d151100-b7e9-11e9-9485-29d49f03b516.png)

2. Images wrong mime type in network console.
![Screen Shot 2019-08-06 at 01 22 33](https://user-images.githubusercontent.com/914534/62486407-66b65880-b7e9-11e9-9787-7e1c5e0ba0b8.png)
![Screen Shot 2019-08-06 at 01 22 55](https://user-images.githubusercontent.com/914534/62486422-7170ed80-b7e9-11e9-88ec-133c4833191d.png)

### Causes
```php
$mimeType = $fileData->mime;
```
This will only return mime object from database. We need the `name` column instead.

```php
$isImage = strpos($mimeType, 'image');
```
This will cause the conditional block below unusable because it will always return **falsy** value. When the mime type is `image/png`, it will return `0`, since `strpos()` return the index of first occurence in the string.

This case, we need strongly checked the returned value type, which is boolean false.